### PR TITLE
Fix spelling of Details and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Single file library for [Kealper](https://github.com/Kealper)'s geoip utility wr
 ```go
 package main
 
-import "fmt"
-import "github.com/JoshuaDoes/goeip"
+import (
+	"fmt"
+
+	"github.com/JoshuaDoes/goeip"
+)
 
 func main() {
 	result, err := goeip.Lookup("joshuadoes.com")

--- a/goeip.go
+++ b/goeip.go
@@ -55,7 +55,7 @@ func Lookup(host string) (*Result, error) {
 
 	if err == nil {
 		if data.Error > 0 {
-			return data, fmt.Errorf("goeip: %s", data.Detail)
+			return data, fmt.Errorf("goeip: %s", data.Details)
 		}
 	}
 


### PR DESCRIPTION
# Changes:
8608fdc - Fix build error on line 58 by changing `Detail` to `Details`
40c7635 - Update README to use `import (...)` syntax instead of two separate import statements